### PR TITLE
Introduce Create GitHub issue button

### DIFF
--- a/classes/GithubIssueFormatter.php
+++ b/classes/GithubIssueFormatter.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+namespace CollectLogsModule;
+
+/**
+ * Class GithubIssueFormatter
+ * Formats log entries as markdown suitable for GitHub issues and sanitizes sensitive information.
+ */
+class GithubIssueFormatter
+{
+    /**
+     * @var TransformMessage
+     */
+    private $transform;
+	
+	private $adminSeg;    // e.g. "admin123"
+    private $adminFsPath; // e.g. "/var/www/html/admin123"
+
+    /**
+     * GithubIssueFormatter constructor.
+     *
+     * @param TransformMessage $transform
+     */
+    public function __construct(TransformMessage $transform, ?string $adminSeg = null, ?string $adminFsPath = null)
+    {
+        $this->transform    = $transform;
+        $this->adminSeg     = $adminSeg ?: null;
+        $this->adminFsPath  = $adminFsPath ?: null;
+    }
+
+    /**
+     * Sanitize string by removing sensitive information such as tokens, passwords, emails, cookies and admin path
+     *
+     * @param string $text
+     * @return string
+     */
+    public function sanitize(string $text): string
+	{
+		// 1) run custom transform
+		$text = $this->transform->transform($text);
+
+		// 2) normalize newlines and decode escaped \n
+		$text = str_replace(["\r\n", "\r"], "\n", $text);
+		$text = preg_replace('/\\\\r?\\\\n/', "\n", $text);
+
+		// 3) hide admin path + basename using detected admin folder
+		$text = $this->maskAdminFolder($text);
+
+		// Keep scheme and replace domain
+		$text = preg_replace('#\b(https?://)[^/\s]+#i', '$1[domain]', $text);
+
+		// Also handle bare hosts without scheme (avoid emails with (?<!@))
+		//$text = preg_replace('#(?<!@)\b[a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(?=/|\b)#i', '[domain]', $text);
+
+		// 4) URLs: ?token=..., &password=...
+		$text = preg_replace('/([?&])(token|secure_key|password|passwd|pwd|email)=([^&\s]+)/i', '$1$2=[removed]', $text);
+
+		// 5) PHP dumps: "token" => "..."
+		$text = preg_replace('/"(token|secure_key|password|passwd|pwd|email)"\s*=>\s*".*?"/i', '"$1"=>"[removed]"', $text);
+
+		// 6) Bracket/colon lists: [token]: "..."
+		$text = preg_replace('/\[(token|secure_key|password|passwd|pwd|email)\]\s*:\s*"[^"]*"/i', '[$1]: "[removed]"', $text);
+		$text = preg_replace('/\[(remote_addr)\]\s*:\s*"[^"]*"/i', '[$1]: "[ip]"', $text);
+
+		// 7) Key: value forms (but NOT inside URLs)
+		$text = preg_replace('/(?<![?&])\b(token|secure_key|password|passwd|pwd|email)\b\s*[:=]\s*\S+/i', '$1: [removed]', $text);
+		$text = preg_replace('/(?<![?&])\bremote_addr\b\s*[:=]\s*\S+/i', 'remote_addr: [ip]', $text);
+
+		// 8) HTTP Cookie header line
+		$text = preg_replace('/^Cookie:\s*[^\r\n]*/im', 'Cookie: [removed]', $text);
+
+		// 9) Emails anywhere
+		$text = preg_replace('/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i', '[email]', $text);
+
+		// 10) IPv4 dotted anywhere
+		$text = preg_replace('/\b(?:\d{1,3}\.){3}\d{1,3}\b/', '[ip]', $text);
+
+		// 11) Generic fallback — only if not already sanitized
+		$text = preg_replace('/(?<!\[)\b(password|passwd|token|secure_key|secret)\b(?!\s*[:=]?\s*\[removed\])(?:\s*[:=]\s*[^\s\]"]+)?/i', '$1: [removed]', $text);
+
+		// 12) Collapse accidental duplicates
+		$text = preg_replace('/(\[(?:removed|ip)\])(?:\s*\1)+/i', '$1', $text);
+
+		return $text;
+	}
+
+
+
+
+    /**
+     * Format log and extras into markdown string suitable for GitHub issue
+     *
+     * @param array $log
+     * @param array $extras
+     * @return string
+     */
+    public function format(array $log, array $extras): string
+    {
+        $type = $log['type'] ?? '';
+
+    $md  = "# Error report\n\n";
+    $md .= '**Type:** ' . $this->sanitize($type) . "\n\n";
+
+    $message = $this->sanitize($log['generic_message'] ?? '');
+    if (!empty($log['sample_message']) && $log['sample_message'] !== ($log['generic_message'] ?? '')) {
+        $message .= "\n\n" . $this->sanitize($log['sample_message']);
+    }
+    $md .= "**Message:**\n\n";
+    $md .= "```\n" . $message . "\n```\n\n";
+
+    $location = !empty($log['real_file'])
+        ? ($log['real_file'] . ':' . ($log['real_line'] ?? ''))
+        : (($log['file'] ?? '') . ':' . ($log['line'] ?? ''));
+    $md .= '**Location:** `' . $this->sanitize($location) . "`\n\n";
+
+        foreach ($extras as $extra) {
+			$label   = $this->sanitize($extra['label'] ?? '');
+			$content = $this->sanitize($extra['content'] ?? '');
+			$md     .= '### ' . $label . "\n\n";
+			$md     .= "```\n" . $content . "\n```\n\n";
+		}
+
+        return $md;
+    }
+	
+	/** Replace any occurrence of the BO admin folder with [admin] */
+	private function maskAdminFolder(string $text): string
+	{
+		// If nothing is known, use a conservative heuristic once.
+		if (!$this->adminSeg && !$this->adminFsPath) {
+			return preg_replace(
+				'~(?<=^|[^\w])(admin(?:-dev|[0-9A-Za-z_-]*))(?=(?:/|\\\\|$|\?|\#|\())~i',
+				'[admin]',
+				$text
+			);
+		}
+
+		// 1) Fast path: exact filesystem path(s) — no regex
+		if ($this->adminFsPath) {
+			$fs = str_replace('\\', '/', $this->adminFsPath);
+			$variants = [$fs];
+
+			$real = @realpath($this->adminFsPath);
+			if ($real) {
+				$real = str_replace('\\', '/', $real);
+				if (strcasecmp($real, $fs) !== 0) {
+					$variants[] = $real;
+				}
+			}
+
+			// forward-slash variants
+			$text = str_ireplace($variants, '[admin]', $text);
+
+			// backslash variants (Windows-style)
+			$backVariants = [];
+			foreach ($variants as $v) {
+				$backVariants[] = str_replace('/', '\\', $v);
+			}
+			$text = str_ireplace($backVariants, '[admin]', $text);
+		}
+
+		// 2) Replace the basename only when it’s a path/URL segment
+		if ($this->adminSeg) {
+			$base = $this->adminSeg;
+			$text = preg_replace(
+				'~(?<=^|[^\w])' . preg_quote($base, '~') . '(?=(?:/|\\\\|$|\?|\#|\())~i',
+				'[admin]',
+				$text
+			);
+		}
+
+		// 3) Elided stacktraces: “…/adminXYZ/”
+		$patternBase = $this->adminSeg ? preg_quote($this->adminSeg, '~') : 'admin(?:-dev|[0-9A-Za-z_-]*)';
+		$text = preg_replace(
+			'~(?:(?<=…)|(?<=\.{3}))(?:(?:/|\\\\))' . $patternBase . '(?=(?:/|\\\\))~i',
+			'/[admin]',
+			$text
+		);
+
+		return $text;
+	}
+
+}

--- a/collectlogs.php
+++ b/collectlogs.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2017-2024 thirty bees
+ * Copyright (C) 2022-2022 thirty bees
  *
  * NOTICE OF LICENSE
  *
@@ -13,7 +13,7 @@
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  * @author    thirty bees <modules@thirtybees.com>
- * @copyright 2017-2024 thirty bees
+ * @copyright 2022 - 2022 thirty bees
  * @license   Academic Free License (AFL 3.0)
  */
 

--- a/collectlogs.php
+++ b/collectlogs.php
@@ -13,7 +13,7 @@
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  * @author    thirty bees <modules@thirtybees.com>
- * @copyright 2017 - 2024 thirty bees
+ * @copyright 2017-2024 thirty bees
  * @license   Academic Free License (AFL 3.0)
  */
 

--- a/collectlogs.php
+++ b/collectlogs.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2022-2022 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
@@ -13,7 +13,7 @@
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  * @author    thirty bees <modules@thirtybees.com>
- * @copyright 2022 - 2022 thirty bees
+ * @copyright 2017 - 2024 thirty bees
  * @license   Academic Free License (AFL 3.0)
  */
 

--- a/controllers/admin/AdminCollectLogsBackendController.php
+++ b/controllers/admin/AdminCollectLogsBackendController.php
@@ -1,9 +1,6 @@
 <?php
-
-use CollectLogsModule\Severity;
-
 /**
- * Copyright (C) 2017-2024 thirty bees
+ * Copyright (C) 2022-2022 thirty bees
  *
  * NOTICE OF LICENSE
  *
@@ -16,9 +13,15 @@ use CollectLogsModule\Severity;
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  * @author    thirty bees <modules@thirtybees.com>
- * @copyright 2017-2024 thirty bees
+ * @copyright 2022 - 2022 thirty bees
  * @license   Academic Free License (AFL 3.0)
  */
+
+use CollectLogsModule\Severity;
+use CollectLogsModule\GithubIssueFormatter;
+
+require_once _PS_MODULE_DIR_.'collectlogs/classes/GithubIssueFormatter.php';
+require_once _PS_MODULE_DIR_.'collectlogs/classes/TransformMessage.php';
 
 class AdminCollectLogsBackendController extends ModuleAdminController
 {
@@ -39,24 +42,28 @@ class AdminCollectLogsBackendController extends ModuleAdminController
 
         parent::__construct();
 
-        $this->_select .= implode(",\n", [
+        // Build clean select
+        $this->_select = implode(",\n", [
             'extra.location',
             'extra.total',
             'extra.last_seen',
         ]);
-        $this->_select .= ',';
-        $this->_select .= ',';
-        $this->_defaultOrderBy = 'a.date_add';
-        $this->_defaultOrderWay = 'DESC';
+
+        // Order without alias (core backticks the token)
+        $this->_orderBy = 'date_add';
+        $this->_orderWay = 'DESC';
+
         $join = (new DbQuery())
             ->select('l.id_collectlogs_logs AS id_collectlogs_logs')
             ->select('CONCAT(l.file, IF(l.line, CONCAT(":", l.line), "")) AS location')
             ->select('SUM(s.count) AS total')
             ->select('DATEDIFF(NOW(), MAX(s.`dimension`)) AS last_seen')
             ->from('collectlogs_logs', 'l')
-            ->innerJoin('collectlogs_stats', 's', '(s.id_collectlogs_logs = l.id_collectlogs_logs)')
+            ->innerJoin('collectlogs_stats', 's', 's.id_collectlogs_logs = l.id_collectlogs_logs')
             ->groupBy('id_collectlogs_logs');
-        $this->_join .= " INNER JOIN ($join) AS extra ON (extra.id_collectlogs_logs = a.id_collectlogs_logs)";
+
+        // Embed the subquery
+        $this->_join .= ' INNER JOIN ('.$join->build().') AS extra ON (extra.id_collectlogs_logs = a.id_collectlogs_logs)';
 
         $this->actions = ['view', 'delete'];
         $this->bulk_actions = [
@@ -188,6 +195,10 @@ class AdminCollectLogsBackendController extends ModuleAdminController
         $template = $this->createTemplate('log-view.tpl');
         $template->assign($log);
         $template->assign('extraSections', $extras);
+        
+        $formatter = new GithubIssueFormatter($this->module->getTransformMessage());
+        $template->assign('githubIssue', $formatter->format($log, $extras));
+        
         return $template->fetch();
     }
 
@@ -213,13 +224,101 @@ class AdminCollectLogsBackendController extends ModuleAdminController
         $this->page_header_toolbar_btn['settings'] = [
             'icon' => 'process-icon-cogs',
             'href' => $this->context->link->getAdminLink('AdminModules', true, [
-                'configure' => $this->module->name,
-                'module_name' => $this->module->name
+                'configure'   => $this->module->name,
+                'module_name' => $this->module->name,
             ]),
             'desc' => $this->l('Settings'),
         ];
+
+        if (Tools::isSubmit('viewcollectlogs_logs')) {
+            $href = $this->context->link->getAdminLink(
+                'AdminCollectLogsBackend',
+                true,
+                [
+                    $this->identifier      => (int) Tools::getValue($this->identifier),
+                    'create_github_issue'  => 1,
+                ]
+            );
+
+            $this->page_header_toolbar_btn['github_issue'] = [
+                'icon' => 'process-icon-new',
+                'href' => $href,
+                'desc' => $this->l('Create GitHub issue'),
+                'target'     => '_blank',
+            ];
+        }
+    }
+    
+    public function postProcess()
+    {
+        parent::postProcess();
+
+        if (Tools::isSubmit('create_github_issue')) {
+            $this->processCreateGithubIssue();
+        }
     }
 
+    /**
+     * Build the issue body and redirect to GitHub’s “new issue” page with
+     * prefilled title & body (GET params).
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    protected function processCreateGithubIssue()
+    {
+        $id = (int) Tools::getValue($this->identifier);
+        if (!$id) {
+            $this->errors[] = $this->l('Missing log ID');
+            return;
+        }
+
+        $db = Db::getInstance();
+        $log = $db->getRow((new DbQuery())
+            ->select('*')
+            ->from('collectlogs_logs')
+            ->where('id_collectlogs_logs = '.$id)
+        );
+        if (!$log) {
+            $this->errors[] = $this->l('Object not found');
+            return;
+        }
+
+        $extras = $db->getArray((new DbQuery())
+            ->select('*')
+            ->from('collectlogs_extra')
+            ->where('id_collectlogs_logs = '.$id)
+        );
+
+        list($adminSeg, $adminFsPath) = $this->detectAdminFolder();
+
+        $transform = $this->module->getTransformMessage(); // returns the concrete implementation
+        $formatter = new \CollectLogsModule\GithubIssueFormatter(
+            $transform,
+            $adminSeg,
+            $adminFsPath
+        );
+        $body  = $formatter->format($log, $extras);
+
+        // Keep URL reasonably short — trim if huge (browser URL limits vary)
+        $max = 7000;
+        if (Tools::strlen($body) > $max) {
+            $body = Tools::substr($body, 0, $max) . "\n\n---\n" .
+                    '_[Truncated. See the error logs screen for full details.]_';
+        }
+
+        $title = sprintf('Error: %s (%s:%s)',
+            isset($log['type']) ? $log['type'] : 'Log',
+            isset($log['file']) ? $log['file'] : 'file',
+            isset($log['line']) ? $log['line'] : '?'
+        );
+
+        $url = 'https://github.com/thirtybees/thirtybees/issues/new'
+             . '?title=' . rawurlencode($title)
+             . '&body='  . rawurlencode($body);
+
+        Tools::redirectAdmin($url);
+    }
 
     /**
      * @param int $value
@@ -243,4 +342,42 @@ class AdminCollectLogsBackendController extends ModuleAdminController
         return '<span class="badge badge-success">' . sprintf($this->l('%s days ago'), $value) . '</span>';
     }
 
+    private function detectAdminFolder(): array
+    {
+        $seg = null;
+        $fsPath = null;
+
+        // A) Filesystem: admin/index.php → dirname is the admin folder
+        if (!empty($_SERVER['SCRIPT_FILENAME'])) {
+            $dir = str_replace('\\', '/', dirname($_SERVER['SCRIPT_FILENAME']));
+            $base = basename($dir);
+            if ($base && preg_match('/^admin(?:-dev|[0-9A-Za-z_-]*)$/i', $base)) {
+                $seg = $base;
+                $fsPath = $dir;
+                return [$seg, $fsPath];
+            }
+        }
+
+        // B) URL path after __PS_BASE_URI__: /<base>/admin123/index.php
+        $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH) ?: '';
+        if ($path !== '' && defined('__PS_BASE_URI__')) {
+            $rest = ltrim(substr($path, strlen(__PS_BASE_URI__)), '/');
+            $first = strtok($rest, '/');
+            if ($first && preg_match('/^admin(?:-dev|[0-9A-Za-z_-]*)$/i', $first)) {
+                $seg = $first;
+                // Try to guess FS path from SCRIPT_FILENAME if available
+                if (!empty($_SERVER['SCRIPT_FILENAME'])) {
+                    $sfDir = str_replace('\\', '/', dirname($_SERVER['SCRIPT_FILENAME']));
+                    // If the current script is in /.../<seg>, use that
+                    if (preg_match('#/'.preg_quote($seg, '#').'$#i', $sfDir)) {
+                        $fsPath = $sfDir;
+                    }
+                }
+                return [$seg, $fsPath];
+            }
+        }
+
+        // C) Last resort: nothing detected
+        return [null, null];
+    }
 }

--- a/controllers/admin/AdminCollectLogsBackendController.php
+++ b/controllers/admin/AdminCollectLogsBackendController.php
@@ -1,6 +1,10 @@
 <?php
+
+use CollectLogsModule\Severity;
+use CollectLogsModule\GithubIssueFormatter;
+
 /**
- * Copyright (C) 2022-2022 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
@@ -13,12 +17,9 @@
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  * @author    thirty bees <modules@thirtybees.com>
- * @copyright 2022 - 2022 thirty bees
+ * @copyright 2017-2024 thirty bees
  * @license   Academic Free License (AFL 3.0)
  */
-
-use CollectLogsModule\Severity;
-use CollectLogsModule\GithubIssueFormatter;
 
 require_once _PS_MODULE_DIR_.'collectlogs/classes/GithubIssueFormatter.php';
 require_once _PS_MODULE_DIR_.'collectlogs/classes/TransformMessage.php';


### PR DESCRIPTION
Related to: https://github.com/thirtybees/collectlogs/issues/10

-Adds a Create GitHub issue button on the log view that opens GitHub’s “new issue” page with a prefilled title and markdown body for the selected log.

-Redacts domains, tokens, passwords, emails, cookies, and IPs.